### PR TITLE
Workaround Emacs bug #18845

### DIFF
--- a/hack-mode.el
+++ b/hack-mode.el
@@ -20,6 +20,11 @@
 (eval-when-compile
   (require 'regexp-opt))
 
+;; Work around emacs bug#18845
+(eval-and-compile
+  (when (and (= emacs-major-version 24) (>= emacs-minor-version 4))
+    (require 'cl)))
+
 (defgroup hack nil
   "Major mode `hack-mode' for editing Hack code."
   :prefix "hack-"


### PR DESCRIPTION
Emacs 24.4 and 24.5 cannot use this package without this workaround
by cc-mode bug. This bug is fixed at Emacs 25.

See also
- https://lists.gnu.org/archive/html/bug-gnu-emacs/2014-10/msg01175.html

For example, Emacs 24.4 or 24.5 cannot enable `hack-mode` by following error.

```
Eval error in the `c-lang-defvar' or `c-lang-setver' for `comment-start' (source eval): (void-function cadar)
```

And Emacs 24.4 or 24.5 cannot byte-compile `hack-mode.el` by following error.

```
hack-mode.el:290:1:Error: Symbol's function definition is void: set-difference
```
